### PR TITLE
Run parts of the publish workflow on PRs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,9 @@ name: Publish website
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   repository_dispatch:
     types:
       - update
@@ -61,13 +64,25 @@ jobs:
         run: npm ci && npm run build
 
       - name: Setup Pages
+        # runs on push event filtered by branches in the 'on' section above, be
+        # wary of adding more branches without expanding this conditional to
+        # filter for pushes to the main branch
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
+        # runs on push event filtered by branches in the 'on' section above, be
+        # wary of adding more branches without expanding this conditional to
+        # filter for pushes to the main branch
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'public'
 
       - name: Deploy to GitHub Pages
+        # runs on push event filtered by branches in the 'on' section above, be
+        # wary of adding more branches without expanding this conditional to
+        # filter for pushes to the main branch
+        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
This runs `npm run build` for pull requests so that any issues can be mitigated before they're merged to the `main` branch. For simplicity of maintenance the existing "Publish website" workflow is reused instead of creating a new workflow so that there is a single workflow definition that needs to be maintained. The publishing of the website is skipped for pull requests using the conditional on the event type being "push", so that the publishing to GitHub pages is skipped for pull requests.

The existing permissions block is kept as is and should apply only to pushes to the `main` branch. This is safe as long as "Send write tokens to workflows from pull requests" is not configured in the repository
settings. See: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview