### PR TITLE
Checks workflow for pull requests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,52 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Check pull request
+
+'on':
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  antora:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.npm
+          key: docs-${{ hashFiles('package-lock.json') }}
+          restore-keys: docs-
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+
+      - name: Generate website
+        run: npm ci && npm run build


### PR DESCRIPTION
This runs `npm run build` for pull requests so that any issues can be mitigated before they're merged to the `main` branch. The existing workflow was copied and adapted to trigger on pull requests. Having the GitHub pages environment defined in the publish workflow it was not possible to reuse the existing workflow due to security implications of trying to allow publishing to GitHub pages from pull requests.