### PR TITLE
Update nav-cli.adoc

### DIFF
--- a/docs/modules/ROOT/nav-cli.adoc
+++ b/docs/modules/ROOT/nav-cli.adoc
@@ -3,9 +3,9 @@
 ** xref:cli/proc_disabled_java_dependencies.adoc[Configuring Java builds with disabled dependencies rebuild].
 ** xref:cli/creating_a_custom_application_test_with_test_pipelines.adoc[Creating a custom application test with test pipelines]
 ** xref:cli/delete_application.adoc[Deleting an application from CLI].
+** xref:cli/proc_managed_services_onboarding.adoc[Managed services team onboarding]
 
 ////
-I'm commenting out these xrefs for now because Burr said these pages are currently unsupported. --Christian (csears@redhat.com), 2/6/2023
+I'm commenting out this xref for now because Burr said this page is currently unsupported. --Christian (csears@redhat.com), 2/16/2023
 ** xref:cli/proc_release_application.adoc[Releasing an application]
-** xref:cli/proc_managed_services_onboarding.adoc[Managed services team onboarding]
 ////


### PR DESCRIPTION
This will add the CLI onboarding page back into the nav menu.