### PR TITLE
Replace 'Stonesoup' with '{ProductName}'

### DIFF
--- a/docs/modules/ROOT/pages/cli/delete_application.adoc
+++ b/docs/modules/ROOT/pages/cli/delete_application.adoc
@@ -6,7 +6,7 @@ WARNING: If you delete an application permanently, you delete all the components
 
 .*Prerequisites*
 
-* You successfully signed in to Stonesoup.
+* You successfully signed in to {ProductName}.
 * You have at least one application.
 
 .*Procedures*

--- a/docs/modules/ROOT/pages/glossary/index.adoc
+++ b/docs/modules/ROOT/pages/glossary/index.adoc
@@ -10,10 +10,10 @@ The ability to update and manage Build Pipelines for each component in an applic
 A Kubernetes deployment, which includes nodes that run containerized applications, and a control plane that manages the nodes.
 
 == Commit 
-A change to one or more files. In Stonesoup, commits that you make to a linked repository move through the pipeline and automatically get published.
+A change to one or more files. In {ProductName}, commits that you make to a linked repository move through the pipeline and automatically get published.
 
 == Component 
-An image that Stonesoup builds from source code in a repository. One or more components that run together form an application.
+An image that {ProductName} builds from source code in a repository. One or more components that run together form an application.
 
 == Conftest 
 A utility for testing structured configuration data. Use Conftest to validate container information.
@@ -84,8 +84,8 @@ A set of component and container images that specifies which components should b
 == Static environment 
 A set of compute resources that you can use to develop, test, and stage your applications before you release them. You can share static environments across all applications in the workspace. 
 
-== Stonesoup 
-A platform to automate the process of building, testing, and deploying applications to the hybrid cloud. Stonesoup offers enterprise-grade security and customizable feature sets.   
+== {ProductName} 
+A platform to automate the process of building, testing, and deploying applications to the hybrid cloud. {ProductName} offers enterprise-grade security and customizable feature sets.   
 
 == Supply chain Levels for Software Artifacts (SLSA) 
 A link:https://slsa.dev/[security framework] that helps prevent tampering by securing the packages and infrastructure of customers’ projects.

--- a/docs/modules/ROOT/pages/how-to-guides/delete_application.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/delete_application.adoc
@@ -6,7 +6,7 @@ WARNING: If you delete an application permanently, you delete all the components
 
 .*Prerequisites*
 
-* You successfully signed in to Stonesoup.
+* You successfully signed in to {ProductName}.
 * You have at least one application.
 
 .*Procedures*

--- a/docs/modules/ROOT/pages/how-to-guides/proc_creating_static_environment.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_creating_static_environment.adoc
@@ -4,7 +4,7 @@ You can create static environments within your current workspace and use them to
 
 .*Prerequisites*
 
-* You successfully signed in to Stonesoup.
+* You successfully signed in to {ProductName}.
 
 
 .*Procedures*
@@ -15,7 +15,7 @@ You can create static environments within your current workspace and use them to
 . From the *Deployment strategy* drop-down list, select either *Automatic* or *Manual*.
 
 +
-NOTE: The deployment strategy handles any changes that you make to your code. If you select *Manual*, you must manually promote any new component updates to the environment. If you select *Automatic*, Stonesoup automatically deploys new component updates to the environment. You can change the deployment strategy when you promote new component updates.
+NOTE: The deployment strategy handles any changes that you make to your code. If you select *Manual*, you must manually promote any new component updates to the environment. If you select *Automatic*, {ProductName} automatically deploys new component updates to the environment. You can change the deployment strategy when you promote new component updates.
 
 . From the *Order in continuous delivery* drop-down list, select an option that will be the default for your application. 
 


### PR DESCRIPTION
This PR replaces "Stonesoup" with "{ProductName}" in 4 different files, to make the naming consistent throughout our user-accessible docs. 