### PR TITLE
Update cli-sbom.adoc

### DIFF
--- a/docs/modules/ROOT/pages/cli/cli-sbom.adoc
+++ b/docs/modules/ROOT/pages/cli/cli-sbom.adoc
@@ -1,28 +1,28 @@
-= Download SBOMs
+= Downloading SBOMs
 
 :toc: left
 :icons: font
 :numbered:
 :source-highlighter: highlightjs
 
-== Software Bill of Materials
-A software bill of materials (SBOM) provides greater transparency for your software supply chain. In {ProductName}, an SBOM lists all the software libraries that a xref:../glossary/index.adoc#_component[component] uses. Those libraries may enable specific functionality, facilitate development, or serve some other purpose. 
+== Software bill of materials
+A software bill of materials (SBOM) provides greater transparency for your software supply chain. In {ProductName}, an SBOM lists all the software libraries that a xref:../glossary/index.adoc#_component[component] uses. Those libraries might enable specific functionality, facilitate development, or serve some other purpose. 
 
-You can use an SBOM to better understand your software’s composition, identify vulnerabilities, and assess the potential impact of any security issues that may arise. You may also need to provide your customers with a component’s SBOM to comply with cybersecurity regulations. 
+You can use an SBOM to better understand the composition of your software, identify vulnerabilities, and assess the potential impact of any security issues that might arise. You might also need to provide your customers with an SBOM to comply with cybersecurity regulations. 
 
 == Downloading an SBOM
 
-*Prerequisites*
+.Prerequisites
 
 * Install the link:https://docs.sigstore.dev/cosign/installation/[Cosign] CLI tool.
 
 * Install the link:https://stedolan.github.io/jq/download/[jq] CLI tool.
 
-* xref:cli/getting_started_in_cli.adoc[Login] to {ProductName}.
+* xref:cli/getting_started_in_cli.adoc[Log in] to {ProductName}.
 
-*Procedure*
+.Procedure
 
-Complete the following steps to download a component's SBOM:
+Complete the following steps to download a component SBOM:
 
 . List your components.
 +
@@ -31,7 +31,7 @@ Complete the following steps to download a component's SBOM:
 $ oc get components
 ----
 +
-.. Example output:
+.Example output
 
 +
 [source]
@@ -41,7 +41,7 @@ devfile-sample-go-basic-8wqt       8m54s True     OK       Updated
 devfile-sample-python-basic-ikch   20d   True     OK       Updated
 ----
 
-. Choose which component's SBOM you want to download. Then use `oc get` and jq to get that component's image path.
+. Choose which component SBOM you want to download, then enter `oc get` and jq to get the component image path.
 
 +
 [source]
@@ -50,7 +50,7 @@ $ oc get component <component name> -ojson | jq '.status.containerImage'
 ----
 
 +
-.. Example:
+.Example
 
 +
 [source]
@@ -59,17 +59,10 @@ $ oc get component devfile-sample-python-basic-ikch -ojson | jq '.status.contain
     "quay.io/redhat-appstudio/user-workload@sha256:<output omitted>"
 ----
 
-. Use Cosign to download the SBOM. Pass the image path, from the output of the last command, as an argument into Cosign's `download sbom` command. Be sure to delete any quotation marks around the image path.
+. Use Cosign to download the SBOM. From the output of the last command, pass the image path as an argument into Cosign's `download sbom` command, like in the following example. Be sure to delete any quotation marks around the image path.
 
 +
-[source]
-----
-$ cosign download sbom <image path>
-----
-
-+
-.. Example:
-
+.Example
 +
 [source]
 ----
@@ -77,8 +70,12 @@ $ cosign download sbom quay.io/redhat-appstudio/user-workload@sha256:<output omi
 ----
 
 +
-.. Cosign prints a warning about the authenticity of the SBOM, since it is unsigned. You can still use this SBOM for standard business processes, like providing an SBOM to your customers. And in the future, {ProductName} will produce signed SBOMs. However, do not use this unsigned SBOM as a legal document. 
-
+.. Because  the SBOM is unsigned, Cosign displays the following warning about its authenticity. You can still use this SBOM for standard business processes, like providing an SBOM to your customers. 
++
+[IMPORTANT]
+====
+Do not use this unsigned SBOM as a legal document. 
+====
 +
 [source]
 ----  
@@ -88,7 +85,7 @@ or verify its signature using 'cosign verify --key <key path> --attachment sbom 
 ----
 
 +
-.. To view and use the SBOM more easily, you may want to redirect the output:
+.. (Optional) To view and use the SBOM more easily, you can redirect the output:
 
 +
 [source]
@@ -96,16 +93,16 @@ or verify its signature using 'cosign verify --key <key path> --attachment sbom 
 $ cosign download sbom quay.io/redhat-appstudio/user-workload@sha256:<output omitted> > sbom.txt
 ----
 
-== Understanding the SBOM
-In the SBOM, as this sample excerpt shows, you can find the following information about each library the component uses:
+== Component library information in an SBOM
+In any SBOM, you can find the following information about each library the component uses so you can verify that each one is safely sourced, updated, and compliant:
 
-. Its author or publisher
-. Its name
-. Its version
-. Its licenses
-
-This information helps you verify that individual libraries are safely-sourced, updated, and compliant. 
-
+* Author or publisher
+* Name
+* Version
+* Licenses
++
+.Example
++
 [source]
 ----
 {

--- a/docs/modules/ROOT/pages/cli/cli-sbom.adoc
+++ b/docs/modules/ROOT/pages/cli/cli-sbom.adoc
@@ -1,4 +1,4 @@
-= Downloading SBOMs
+= SBOMs
 
 :toc: left
 :icons: font
@@ -6,23 +6,21 @@
 :source-highlighter: highlightjs
 
 == Software bill of materials
-A software bill of materials (SBOM) provides greater transparency for your software supply chain. In {ProductName}, an SBOM lists all the software libraries that a xref:../glossary/index.adoc#_component[component] uses. Those libraries might enable specific functionality, facilitate development, or serve some other purpose. 
+A software bill of materials (SBOM) provides greater transparency for your software supply chain. In {ProductName}, an SBOM is a list of all the software libraries that a xref:../glossary/index.adoc#_component[component] uses. Those libraries might enable specific functionality, facilitate development, or serve some other purpose. 
 
 You can use an SBOM to better understand the composition of your software, identify vulnerabilities, and assess the potential impact of any security issues that might arise. You might also need to provide your customers with an SBOM to comply with cybersecurity regulations. 
 
 == Downloading an SBOM
 
-.Prerequisites
+*Prerequisites*
 
 * Install the link:https://docs.sigstore.dev/cosign/installation/[Cosign] CLI tool.
 
 * Install the link:https://stedolan.github.io/jq/download/[jq] CLI tool.
 
-* xref:cli/getting_started_in_cli.adoc[Log in] to {ProductName}.
+* xref:cli/getting_started_in_cli.adoc[Login] to {ProductName}.
 
-.Procedure
-
-Complete the following steps to download a component SBOM:
+*Procedure*
 
 . List your components.
 +
@@ -41,7 +39,7 @@ devfile-sample-go-basic-8wqt       8m54s True     OK       Updated
 devfile-sample-python-basic-ikch   20d   True     OK       Updated
 ----
 
-. Choose which component SBOM you want to download, then enter `oc get` and jq to get the component image path.
+. Choose which component's SBOM you want to download. Then use `oc get` and the jq CLI tool to get the component image path.
 
 +
 [source]
@@ -59,7 +57,7 @@ $ oc get component devfile-sample-python-basic-ikch -ojson | jq '.status.contain
     "quay.io/redhat-appstudio/user-workload@sha256:<output omitted>"
 ----
 
-. Use Cosign to download the SBOM. From the output of the last command, pass the image path as an argument into Cosign's `download sbom` command, like in the following example. Be sure to delete any quotation marks around the image path.
+. Use Cosign to download the SBOM. From the output of the last command, pass the image path as an argument into Cosign's `download sbom` command. Be sure to delete any quotation marks around the image path.
 
 +
 .Example
@@ -70,7 +68,7 @@ $ cosign download sbom quay.io/redhat-appstudio/user-workload@sha256:<output omi
 ----
 
 +
-.. Because  the SBOM is unsigned, Cosign displays the following warning about its authenticity. You can still use this SBOM for standard business processes, like providing an SBOM to your customers. 
+.. Because  the SBOM is unsigned, Cosign displays a warning about its authenticity. You can still use this SBOM for standard business processes, like providing an SBOM to your customers. 
 +
 [IMPORTANT]
 ====
@@ -85,7 +83,7 @@ or verify its signature using 'cosign verify --key <key path> --attachment sbom 
 ----
 
 +
-.. (Optional) To view and use the SBOM more easily, you can redirect the output:
+.. (Optional) To view the full SBOM in a searchable format, you can redirect the output:
 
 +
 [source]
@@ -93,16 +91,18 @@ or verify its signature using 'cosign verify --key <key path> --attachment sbom 
 $ cosign download sbom quay.io/redhat-appstudio/user-workload@sha256:<output omitted> > sbom.txt
 ----
 
-== Component library information in an SBOM
-In any SBOM, you can find the following information about each library the component uses so you can verify that each one is safely sourced, updated, and compliant:
+== Reading the SBOM
+In any SBOM, you can find the following information about each library the component uses:
 
-* Author or publisher
-* Name
-* Version
-* Licenses
-+
-.Example
-+
+. Author or publisher
+. Name
+. Version
+. Licenses
+
+You can use this information to verify that each library is safely sourced, updated, and compliant.
+
+Example SBOM
+
 [source]
 ----
 {
@@ -137,4 +137,4 @@ In any SBOM, you can find the following information about each library the compo
 ----
 
 == Additional resources
-* xref:../how-to-guides/webui-sbom.adoc[Download SBOMs in the web UI]
+* xref:../how-to-guides/webui-sbom.adoc[SBOMs in the web UI]


### PR DESCRIPTION
1. @gtrivedi88 are we not modularizing?
2. We need to decide on file naming conventions.
3. But what is an SBOM? A file? A package/bundle of files?
4. I don't understand this line: ". Choose which SBOM you want to download, then enter `oc get` and jq to get the component image path." If the only way to use an SBOM is with the CLI, you should state that. Also, what does "and jq" mean?
5. Can't refer to future bc then we have to remember to change it after the update.
6. "more easily" is editorial. instead, we should say something like, "To view and use the SBOM with having to _______."