### PR TITLE
Capitalize "Enterprise Contract" in glossary

### DIFF
--- a/docs/modules/ROOT/pages/glossary/index.adoc
+++ b/docs/modules/ROOT/pages/glossary/index.adoc
@@ -18,7 +18,7 @@ An image that {ProductName} builds from source code in a repository. One or more
 == Conftest 
 A utility for testing structured configuration data. Use Conftest to validate container information.
 
-== Enterprise contract (EC) 
+== Enterprise Contract (EC) 
 A set of release policies that you apply to your managed environment. Use the EC to prevent the release of Supply chain Levels for Software Artifacts (SLSA) that are non-compliant. 
 
 == Ephemeral environment
@@ -58,7 +58,7 @@ A practice that defines pipelines with source code in Git. Pipelines as Code is 
 Systems that retain the history and details of builds. 
 
 == PipelineRun
-A collection of TaskRuns that are arranged in a specific order of execution. A valid Pipeline is compliant with the customer’s enterprise contract.
+A collection of TaskRuns that are arranged in a specific order of execution. A valid Pipeline is compliant with the customer’s Enterprise Contract.
 
 == Pipeline service 
 A managed service that securely runs Tekton Pipelines. It also stores the metadata and Pipeline logs that are related to an executed Pipeline in a separate database.
@@ -70,7 +70,7 @@ A test that assesses the security of build inputs and outputs with vulnerability
 A component that removes resources that are associated with the completed PipelineRuns. The system assigns resources, such as pods, to every PipelineRun. Without a pruner, these resources remain in the cluster indefinitely, even after the system completes the PipelineRun. 
 
 == Release pipeline 
-A pipeline that defines the process for validating snapshots against the enterprise contract. They also provide an array of release destinations other than GitOps deployments. 
+A pipeline that defines the process for validating snapshots against the Enterprise Contract. They also provide an array of release destinations other than GitOps deployments. 
 
 == Security testing 
 A process that determines if images meet security quality standards.


### PR DESCRIPTION
Re-creating this PR to hopefully deal with technical issues. PR capitalizes all instances of "Enterprise Contract" in glossary. 